### PR TITLE
Feature/profile management

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { ClassModule } from "./modules/class";
 import { SubjectModule } from "./modules/subject";
 import { QuizModule } from "./modules/quiz/quiz.module";
 import { SubscriptionModule } from "./modules/subscription/subscription.module";
+import { UserModule } from "./modules/user/user.module";
 
 import AppConfig from "./core/interfaces/config.global";
 
@@ -44,6 +45,7 @@ import AppConfig from "./core/interfaces/config.global";
     SubjectModule,
     QuizModule,
     SubscriptionModule,
+    UserModule,
   ],
 })
 export class AppModule {}

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -277,7 +277,7 @@ import { IPasswordResetTokenRepository } from "./domain/repositories/passwordRes
       inject: [LoggerService, "AUTH_IDENTITY_PROVIDER"],
     },
   ],
-  exports: [AuthFacade],
+  exports: [AuthFacade, "AUTH_IDENTITY_PROVIDER"],
 })
 export class AuthModule {
   constructor(

--- a/src/modules/auth/domain/entities/authIdentity.entity.ts
+++ b/src/modules/auth/domain/entities/authIdentity.entity.ts
@@ -115,6 +115,16 @@ export class AuthIdentityEntity {
     };
   }
 
+  updateUsername(newUsername: string): void {
+    this.props = {
+      ...this.props,
+      username: newUsername.trim(),
+      isEmailVerified: false,
+      emailVerifiedAt: null,
+      updatedAt: new Date(),
+    };
+  }
+
   unlockAccount(): void {
     this.props = {
       ...this.props,

--- a/src/modules/organization/domain/entities/organization.entity.ts
+++ b/src/modules/organization/domain/entities/organization.entity.ts
@@ -39,6 +39,15 @@ export class OrganizationEntity {
     return true;
   }
 
+  updateName(name: string): void {
+    this.props = {
+      ...this.props,
+      name: name.trim(),
+      slug: GeneralUtils.generateSlug(name.trim()),
+      updatedAt: new Date(),
+    };
+  }
+
   get id(): string {
     return this.props.id;
   }

--- a/src/modules/organization/domain/entities/user.entity.ts
+++ b/src/modules/organization/domain/entities/user.entity.ts
@@ -122,6 +122,14 @@ export class UserEntity {
     };
   }
 
+  updateEmail(email: string): void {
+    this.props = {
+      ...this.props,
+      email: email.trim(),
+      updatedAt: new Date(),
+    };
+  }
+
   isActive(): boolean {
     return this.props.status === UserStatus.ACTIVE;
   }

--- a/src/modules/organization/domain/repositories/membership.repository.ts
+++ b/src/modules/organization/domain/repositories/membership.repository.ts
@@ -3,10 +3,10 @@ import { MembershipEntity } from "../entities/membership.entity";
 
 export interface IMembershipRepository extends IRepository<MembershipEntity> {
   create(data: MembershipEntity): Promise<MembershipEntity>;
-  findByOrganization(organizationId: string): Promise<MembershipEntity[] | []>;
+  findByOrganization(organizationId: string): Promise<MembershipEntity[]>;
   findByUserIdWithOrganizations(
     userId: string
-  ): Promise<MembershipEntity[] | []>;
+  ): Promise<MembershipEntity[]>;
   findByUserAndOrganization(
     userId: string,
     organizationId: string

--- a/src/modules/organization/infrastructure/repositories/membership.repository.ts
+++ b/src/modules/organization/infrastructure/repositories/membership.repository.ts
@@ -36,7 +36,7 @@ export class MembershipRepository
 
   async findByOrganization(
     organizationId: string
-  ): Promise<MembershipEntity[] | []> {
+  ): Promise<MembershipEntity[]> {
     const ormEntities = await this.directRepository.findBy({ organizationId });
     return this.toEntities(ormEntities);
   }

--- a/src/modules/organization/infrastructure/repositories/user.repository.ts
+++ b/src/modules/organization/infrastructure/repositories/user.repository.ts
@@ -109,8 +109,23 @@ export class UserRepository
   async save(entity: UserEntity): Promise<UserEntity> {
     const repository = this.getTypeOrmRepository();
     const data = entity.toPersistence();
-    const { memberships, ...ormEntity } = await repository.save(data);
-    return UserEntity.reconstitute(ormEntity);
+    // Exclude memberships to avoid TypeORM trying to save relations
+    const saved = await repository.save({
+      id: data.id,
+      firstName: data.firstName,
+      lastName: data.lastName,
+      email: data.email,
+      phoneNumber: data.phoneNumber,
+      avatarUrl: data.avatarUrl,
+      lastLogin: data.lastLogin,
+      status: data.status,
+      role: data.role,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+    });
+    // Exclude memberships from reconstitute to avoid type mismatch
+    const { memberships, ...userWithoutMemberships } = saved;
+    return UserEntity.reconstitute({ ...userWithoutMemberships, memberships: [] });
   }
 
   async delete(id: string): Promise<void> {

--- a/src/modules/organization/organization.module.ts
+++ b/src/modules/organization/organization.module.ts
@@ -257,6 +257,6 @@ import { OrganizationAuthorizationService } from "./domain/services/organization
       inject: [LoggerService, EventStore],
     },
   ],
-  exports: [OrganizationFacade],
+  exports: [OrganizationFacade, "MEMBERSHIP_REPOSITORY"],
 })
 export class OrganizationModule {}

--- a/src/modules/user/application/facades/user.facade.ts
+++ b/src/modules/user/application/facades/user.facade.ts
@@ -1,0 +1,43 @@
+import {
+  GetProfileInput,
+  GetProfileOutput,
+  UpdateProfileInput,
+  UpdateProfileOutput,
+  DeleteAccountInput,
+} from "../../domain/types";
+import { GetProfileUseCase } from "../use-cases/GetProfile.use-case";
+import { UpdateProfileUseCase } from "../use-cases/UpdateProfile.use-case";
+import { DeleteAccountUseCase } from "../use-cases/DeleteAccount.use-case";
+
+export class UserFacade {
+  constructor(
+    private readonly getProfileUseCase: GetProfileUseCase,
+    private readonly updateProfileUseCase: UpdateProfileUseCase,
+    private readonly deleteAccountUseCase: DeleteAccountUseCase
+  ) {}
+
+  async getProfile(data: GetProfileInput): Promise<GetProfileOutput> {
+    try {
+      return await this.getProfileUseCase.execute(data);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async updateProfile(data: UpdateProfileInput): Promise<UpdateProfileOutput> {
+    try {
+      return await this.updateProfileUseCase.execute(data);
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async deleteAccount(data: DeleteAccountInput): Promise<void> {
+    try {
+      return await this.deleteAccountUseCase.execute(data);
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+

--- a/src/modules/user/application/use-cases/DeleteAccount.use-case.ts
+++ b/src/modules/user/application/use-cases/DeleteAccount.use-case.ts
@@ -1,0 +1,113 @@
+import {
+  IUseCase,
+  BaseUseCase,
+  ILoggerService,
+  DomainError,
+  ErrorCode,
+  UserRole,
+  IUnitOfWork,
+} from "src/core";
+
+import { DeleteAccountInput } from "../../domain/types";
+import { IUserRepository } from "../../../organization/domain/repositories/user.repository";
+import { IAuthIdentityRepository } from "../../../auth/domain/repositories/authIdentity.repository";
+import { IOrganizationRepository } from "../../../organization/domain/repositories/organization.repository";
+import { IMembershipRepository } from "../../../organization/domain/repositories/membership.repository";
+import { IAuthStrategy } from "../../../auth/domain/types";
+
+export class DeleteAccountUseCase extends BaseUseCase implements IUseCase {
+  constructor(
+    readonly logger: ILoggerService,
+    private readonly unitOfWork: IUnitOfWork,
+    private readonly userRepository: IUserRepository,
+    private readonly authIdentityRepository: IAuthIdentityRepository,
+    private readonly organizationRepository: IOrganizationRepository,
+    private readonly membershipRepository: IMembershipRepository,
+    private readonly authStrategy: IAuthStrategy
+  ) {
+    super(logger);
+  }
+
+  async execute(data: DeleteAccountInput): Promise<void> {
+    try {
+      const user = await this.userRepository.findByIdWithActiveMemberships(data.userId);
+      if (!user) {
+        throw new DomainError(ErrorCode.USER_NOT_FOUND, "User not found");
+      }
+
+      let isAdmin = false;
+      const ownedOrganizations = await this.organizationRepository.findByOwner(data.userId);
+      for (const org of ownedOrganizations) {
+        if (user.hasRoleInOrganization(org.id, UserRole.ADMIN)) {
+          isAdmin = true;
+          break;
+        }
+      }
+
+      if (!isAdmin) {
+        throw new DomainError(
+          ErrorCode.INVALID_ROLE_FOR_MEMBERSHIP,
+          "Only admins can delete their account"
+        );
+      }
+
+      await this.unitOfWork.withTransaction(async () => {
+        for (const organization of ownedOrganizations) {
+          const memberships = await this.membershipRepository.findByOrganization(organization.id);
+
+          for (const membership of memberships) {
+            if (membership.userId === data.userId) {
+              continue;
+            }
+
+            const memberUser = await this.userRepository.findByIdWithActiveMemberships(membership.userId);
+            if (!memberUser) {
+              continue;
+            }
+
+            const allMemberships = await this.membershipRepository.findByUserIdWithOrganizations(memberUser.id);
+            const activeMemberships = allMemberships.filter((m) => m.isActive());
+
+            if (activeMemberships.length === 1 && activeMemberships[0].organizationId === organization.id) {
+              const memberAuthIdentity = await this.authIdentityRepository.findByUsername(
+                memberUser.email
+              );
+              if (memberAuthIdentity) {
+                try {
+                  await this.authStrategy.deleteIdentity(memberUser.email);
+                } catch (error) {
+                  this.logger.warn(`Failed to delete auth identity for ${memberUser.email}: ${error}`);
+                }
+              }
+              await this.userRepository.delete(memberUser.id);
+            } else {
+              await this.membershipRepository.delete(membership.id);
+            }
+          }
+
+          const adminMembership = memberships.find((m) => m.userId === data.userId);
+          if (adminMembership) {
+            await this.membershipRepository.delete(adminMembership.id);
+          }
+          await this.organizationRepository.delete(organization.id);
+        }
+
+        const authIdentity = await this.authIdentityRepository.findByUsername(user.email);
+        if (authIdentity) {
+          try {
+            await this.authStrategy.deleteIdentity(user.email);
+          } catch (error) {
+            this.logger.warn(`Failed to delete auth identity for ${user.email}: ${error}`);
+          }
+        }
+
+        await this.userRepository.delete(data.userId);
+      });
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
+  async withCompensation(): Promise<void> {}
+}
+

--- a/src/modules/user/application/use-cases/GetProfile.use-case.ts
+++ b/src/modules/user/application/use-cases/GetProfile.use-case.ts
@@ -1,0 +1,35 @@
+import {
+  IUseCase,
+  BaseUseCase,
+  ILoggerService,
+  DomainError,
+  ErrorCode,
+} from "src/core";
+
+import { GetProfileInput, GetProfileOutput } from "../../domain/types";
+import { IUserRepository } from "../../../organization/domain/repositories/user.repository";
+
+export class GetProfileUseCase extends BaseUseCase implements IUseCase {
+  constructor(
+    readonly logger: ILoggerService,
+    private readonly userRepository: IUserRepository
+  ) {
+    super(logger);
+  }
+
+  async execute(data: GetProfileInput): Promise<GetProfileOutput> {
+    try {
+      const user = await this.userRepository.findById(data.userId);
+      if (!user) {
+        throw new DomainError(ErrorCode.USER_NOT_FOUND, "User not found");
+      }
+
+      return user.toPersistence();
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
+  async withCompensation(): Promise<void> {}
+}
+

--- a/src/modules/user/application/use-cases/UpdateProfile.use-case.ts
+++ b/src/modules/user/application/use-cases/UpdateProfile.use-case.ts
@@ -1,0 +1,141 @@
+import {
+  IUseCase,
+  BaseUseCase,
+  ILoggerService,
+  DomainError,
+  ErrorCode,
+  Email,
+  UserRole,
+  IUnitOfWork,
+} from "src/core";
+
+import { UpdateProfileInput, UpdateProfileOutput } from "../../domain/types";
+import { IUserRepository } from "../../../organization/domain/repositories/user.repository";
+import { IAuthIdentityRepository } from "../../../auth/domain/repositories/authIdentity.repository";
+import { AuthIdentityUniquenessService } from "../../../auth/domain/services/authIdentity-uniqueness.service";
+import { IOrganizationRepository } from "../../../organization/domain/repositories/organization.repository";
+import { OrganizationFacade } from "../../../organization/application/facades/organization.facade";
+
+export class UpdateProfileUseCase extends BaseUseCase implements IUseCase {
+  constructor(
+    readonly logger: ILoggerService,
+    private readonly unitOfWork: IUnitOfWork,
+    private readonly userRepository: IUserRepository,
+    private readonly authIdentityRepository: IAuthIdentityRepository,
+    private readonly authIdentityUniquenessService: AuthIdentityUniquenessService,
+    private readonly organizationRepository: IOrganizationRepository,
+    private readonly organizationFacade: OrganizationFacade
+  ) {
+    super(logger);
+  }
+
+  async execute(data: UpdateProfileInput): Promise<UpdateProfileOutput> {
+    try {
+      return await this.unitOfWork.withTransaction(async () => {
+        const user = await this.userRepository.findById(data.userId);
+        if (!user) {
+          throw new DomainError(ErrorCode.USER_NOT_FOUND, "User not found");
+        }
+
+        const updateData: {
+          firstName?: string;
+          lastName?: string;
+        } = {};
+
+        if (data.firstName !== undefined) {
+          updateData.firstName = data.firstName.trim();
+        }
+
+        if (data.lastName !== undefined) {
+          updateData.lastName = data.lastName.trim();
+        }
+
+        if (Object.keys(updateData).length > 0) {
+          user.updateProfile(updateData);
+          await this.userRepository.save(user);
+        }
+
+        if (data.email !== undefined && data.email.trim() !== user.email) {
+          const newEmail = Email.create(data.email.trim());
+          const oldEmail = user.email;
+
+          await this.authIdentityUniquenessService.ensureEmailIsUnique(
+            newEmail.value
+          );
+
+          const authIdentity = await this.authIdentityRepository.findByUsername(
+            oldEmail
+          );
+
+          if (authIdentity) {
+            authIdentity.updateUsername(newEmail.value);
+            await this.authIdentityRepository.save(authIdentity);
+          }
+
+          user.updateEmail(newEmail.value);
+          await this.userRepository.save(user);
+        }
+
+        if (
+          data.organizationId &&
+          data.organizationName !== undefined &&
+          data.organizationName.trim() !== ""
+        ) {
+          const userWithMemberships = await this.userRepository.findByIdWithActiveMemberships(
+            data.userId
+          );
+
+          if (!userWithMemberships) {
+            throw new DomainError(ErrorCode.USER_NOT_FOUND, "User not found");
+          }
+
+          if (
+            !userWithMemberships.hasRoleInOrganization(
+              data.organizationId,
+              UserRole.ADMIN
+            )
+          ) {
+            throw new DomainError(
+              ErrorCode.INVALID_ROLE_FOR_MEMBERSHIP,
+              "Only admins can update organization name"
+            );
+          }
+
+          const organization = await this.organizationRepository.findById(
+            data.organizationId
+          );
+
+          if (!organization) {
+            throw new DomainError(
+              ErrorCode.ORGANIZATION_NOT_FOUND,
+              "Organization not found"
+            );
+          }
+
+          if (organization.name !== data.organizationName.trim()) {
+            const existingOrg = await this.organizationRepository.findByName(
+              data.organizationName.trim()
+            );
+
+            if (existingOrg && existingOrg.id !== data.organizationId) {
+              throw new DomainError(
+                ErrorCode.ORGANIZATION_ALREADY_EXIST,
+                "Organization name already exists"
+              );
+            }
+
+            organization.updateName(data.organizationName.trim());
+            await this.organizationRepository.save(organization);
+          }
+        }
+
+        return user.toPersistence();
+      });
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
+  async withCompensation(): Promise<void> {}
+}
+

--- a/src/modules/user/domain/types.ts
+++ b/src/modules/user/domain/types.ts
@@ -1,0 +1,23 @@
+import { IUser } from "../../organization/domain/types";
+
+export interface GetProfileInput {
+  userId: string;
+}
+
+export interface GetProfileOutput extends IUser {}
+
+export interface UpdateProfileInput {
+  userId: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  organizationId?: string;
+  organizationName?: string;
+}
+
+export interface DeleteAccountInput {
+  userId: string;
+}
+
+export interface UpdateProfileOutput extends IUser {}
+

--- a/src/modules/user/index.ts
+++ b/src/modules/user/index.ts
@@ -1,0 +1,4 @@
+export * from "./user.module";
+export * from "./domain/types";
+export * from "./application/facades/user.facade";
+

--- a/src/modules/user/interface/controllers/profile.controller.ts
+++ b/src/modules/user/interface/controllers/profile.controller.ts
@@ -1,0 +1,125 @@
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from "@nestjs/swagger";
+import { Controller, Get, Put, Delete, Body, UseGuards } from "@nestjs/common";
+
+import { BaseController, AuthGuard, RolesGuard, Roles, CurrentUser, UserRole } from "src/core";
+import type { JWTPayload } from "src/core";
+import { UserFacade } from "../../application/facades/user.facade";
+import { UpdateProfileDto } from "../dto/profile.dto";
+import { AuthFacade } from "../../../auth/application/facades/auth.facade";
+import { ChangePasswordDto } from "../../../auth/interface/dto/auth.dto";
+
+@ApiTags("Profile")
+@Controller("v1/profile")
+export class ProfileController extends BaseController {
+  constructor(
+    private readonly userFacade: UserFacade,
+    private readonly authFacade: AuthFacade
+  ) {
+    super();
+  }
+
+  @Get()
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @ApiOperation({
+    summary: "Récupérer le profil de l'utilisateur connecté",
+    description: "Récupère les informations du profil de l'utilisateur authentifié",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Profil récupéré avec succès",
+  })
+  @ApiResponse({ status: 401, description: "Authentification requise" })
+  @ApiResponse({ status: 404, description: "Utilisateur non trouvé" })
+  async getProfile(@CurrentUser() user: JWTPayload) {
+    const profile = await this.userFacade.getProfile({ userId: user.userId });
+    return this.success(profile);
+  }
+
+  @Put()
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.LEARNING_MANAGER)
+  @ApiOperation({
+    summary: "Mettre à jour le profil de l'utilisateur connecté",
+    description:
+      "Met à jour les informations du profil (prénom, nom, email, nom de l'établissement) de l'utilisateur authentifié. Seul un admin peut mettre à jour le nom de l'établissement.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Profil mis à jour avec succès",
+  })
+  @ApiResponse({ status: 400, description: "Données invalides" })
+  @ApiResponse({ status: 401, description: "Authentification requise" })
+  @ApiResponse({ status: 403, description: "Accès interdit - Admin requis pour modifier le nom de l'établissement" })
+  @ApiResponse({ status: 404, description: "Utilisateur non trouvé" })
+  async updateProfile(
+    @CurrentUser() user: JWTPayload,
+    @Body() dto: UpdateProfileDto
+  ) {
+    const updatedProfile = await this.userFacade.updateProfile({
+      userId: user.userId,
+      firstName: dto.firstname,
+      lastName: dto.lastname,
+      email: dto.email,
+      organizationId: dto.organizationId,
+      organizationName: dto.organizationName,
+    });
+    return this.success(updatedProfile);
+  }
+
+  @Put("password")
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @ApiOperation({
+    summary: "Changer le mot de passe",
+    description:
+      "Change le mot de passe de l'utilisateur authentifié. Nécessite l'ancien mot de passe et le nouveau mot de passe.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Mot de passe modifié avec succès",
+  })
+  @ApiResponse({ status: 400, description: "Mot de passe invalide" })
+  @ApiResponse({
+    status: 401,
+    description: "Non autorisé ou ancien mot de passe invalide",
+  })
+  async changePassword(
+    @CurrentUser() user: JWTPayload,
+    @Body() dto: ChangePasswordDto
+  ) {
+    await this.authFacade.changePassword({
+      userId: user.userId,
+      username: user.username,
+      oldPassword: dto.oldPassword,
+      newPassword: dto.newPassword,
+    });
+    return this.success({
+      message: "Password has been changed successfully",
+    });
+  }
+
+  @Delete()
+  @ApiBearerAuth()
+  @UseGuards(AuthGuard)
+  @ApiOperation({
+    summary: "Supprimer le compte (Admin uniquement)",
+    description:
+      "Supprime définitivement le compte de l'utilisateur admin authentifié, son organisation et toutes les données associées. Les utilisateurs uniquement liés à cette organisation seront également supprimés.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Compte et données associées supprimés avec succès",
+  })
+  @ApiResponse({ status: 401, description: "Authentification requise" })
+  @ApiResponse({ status: 403, description: "Accès interdit - Admin requis" })
+  @ApiResponse({ status: 404, description: "Utilisateur non trouvé" })
+  async deleteAccount(@CurrentUser() user: JWTPayload) {
+    await this.userFacade.deleteAccount({ userId: user.userId });
+    return this.success({
+      message: "Account has been deleted successfully",
+    });
+  }
+}
+

--- a/src/modules/user/interface/dto/profile.dto.ts
+++ b/src/modules/user/interface/dto/profile.dto.ts
@@ -1,0 +1,74 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsString,
+  IsOptional,
+  MinLength,
+  MaxLength,
+  Matches,
+  IsEmail,
+  IsUUID,
+} from "class-validator";
+
+export class UpdateProfileDto {
+  @ApiProperty({
+    description: "Prénom de l'utilisateur",
+    example: "John",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(2, { message: "Le prénom doit contenir au moins 2 caractères" })
+  @MaxLength(50, { message: "Le prénom doit contenir au plus 50 caractères" })
+  @Matches(/^[A-Za-zÀ-ÖØ-öø-ÿ'-\s]+$/, {
+    message: "Le prénom ne peut contenir que des lettres",
+  })
+  firstname?: string;
+
+  @ApiProperty({
+    description: "Nom de l'utilisateur",
+    example: "Doe",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(2, { message: "Le nom doit contenir au moins 2 caractères" })
+  @MaxLength(50, { message: "Le nom doit contenir au plus 50 caractères" })
+  @Matches(/^[A-Za-zÀ-ÖØ-öø-ÿ'-\s]+$/, {
+    message: "Le nom ne peut contenir que des lettres",
+  })
+  lastname?: string;
+
+  @ApiProperty({
+    description: "Email de l'utilisateur",
+    example: "john.doe@example.com",
+    required: false,
+  })
+  @IsOptional()
+  @IsEmail({}, { message: "L'email n'est pas valide" })
+  email?: string;
+
+  @ApiProperty({
+    description: "ID de l'organisation",
+    example: "123e4567-e89b-12d3-a456-426614174000",
+    required: false,
+  })
+  @IsOptional()
+  @IsUUID()
+  organizationId?: string;
+
+  @ApiProperty({
+    description: "Nom de l'établissement",
+    example: "Mon École",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(2, {
+    message: "Le nom de l'établissement doit contenir au moins 2 caractères",
+  })
+  @MaxLength(255, {
+    message: "Le nom de l'établissement doit contenir au plus 255 caractères",
+  })
+  organizationName?: string;
+}
+

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -1,0 +1,165 @@
+import { Module, forwardRef } from "@nestjs/common";
+import { getRepositoryToken, TypeOrmModule } from "@nestjs/typeorm";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { Repository } from "typeorm";
+
+import { LoggerService, ILoggerService, IUnitOfWork, TypeOrmUnitOfWork } from "src/core";
+import { CoreModule } from "src/core/core.module";
+import { OrganizationModule } from "../organization/organization.module";
+import { AuthModule } from "../auth/auth.module";
+import { UserModel } from "../organization/infrastructure/models/user.model";
+import { OrganizationModel } from "../organization/infrastructure/models/organization.model";
+import { UserRepository } from "../organization/infrastructure/repositories/user.repository";
+import { OrganizationRepository } from "../organization/infrastructure/repositories/organization.repository";
+import { IUserRepository } from "../organization/domain/repositories/user.repository";
+import { IOrganizationRepository } from "../organization/domain/repositories/organization.repository";
+import { AuthIdentityRepository } from "../auth/infrastructure/repositories/authIdentity.repository";
+import { IAuthIdentityRepository } from "../auth/domain/repositories/authIdentity.repository";
+import { AuthIdentityUniquenessService } from "../auth/domain/services/authIdentity-uniqueness.service";
+import { AuthIdentityModel } from "../auth/infrastructure/models/authIdentity.model";
+import { OrganizationFacade } from "../organization/application/facades/organization.facade";
+import { AuthFacade } from "../auth/application/facades/auth.facade";
+import { IAuthStrategy } from "../auth/domain/types";
+import { GetProfileUseCase } from "./application/use-cases/GetProfile.use-case";
+import { MembershipRepository } from "../organization/infrastructure/repositories/membership.repository";
+import { MembershipModel } from "../organization/infrastructure/models/membership.model";
+import { IMembershipRepository } from "../organization/domain/repositories/membership.repository";
+import { UpdateProfileUseCase } from "./application/use-cases/UpdateProfile.use-case";
+import { DeleteAccountUseCase } from "./application/use-cases/DeleteAccount.use-case";
+import { UserFacade } from "./application/facades/user.facade";
+import { ProfileController } from "./interface/controllers/profile.controller";
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([UserModel, OrganizationModel, AuthIdentityModel, MembershipModel]),
+    forwardRef(() => CoreModule),
+    forwardRef(() => OrganizationModule),
+    forwardRef(() => AuthModule),
+  ],
+  controllers: [ProfileController],
+  providers: [
+    LoggerService,
+    ConfigService,
+    {
+      provide: "USER_REPOSITORY",
+      useFactory: (
+        ormRepository: Repository<UserModel>,
+        unitOfWork: IUnitOfWork
+      ) => new UserRepository(ormRepository, unitOfWork),
+      inject: [getRepositoryToken(UserModel), TypeOrmUnitOfWork],
+    },
+    {
+      provide: "ORGANIZATION_REPOSITORY",
+      useFactory: (
+        ormRepository: Repository<OrganizationModel>,
+        unitOfWork: IUnitOfWork
+      ) => new OrganizationRepository(ormRepository, unitOfWork),
+      inject: [getRepositoryToken(OrganizationModel), TypeOrmUnitOfWork],
+    },
+    {
+      provide: "MEMBERSHIP_REPOSITORY",
+      useFactory: (
+        ormRepository: Repository<MembershipModel>,
+        unitOfWork: IUnitOfWork
+      ) => new MembershipRepository(ormRepository, unitOfWork),
+      inject: [getRepositoryToken(MembershipModel), TypeOrmUnitOfWork],
+    },
+    {
+      provide: "AUTH_IDENTITY_REPOSITORY",
+      useFactory: (ormRepository: Repository<AuthIdentityModel>) =>
+        new AuthIdentityRepository(ormRepository),
+      inject: [getRepositoryToken(AuthIdentityModel)],
+    },
+    {
+      provide: AuthIdentityUniquenessService,
+      useFactory: (authIdentityRepository: IAuthIdentityRepository) =>
+        new AuthIdentityUniquenessService(authIdentityRepository),
+      inject: ["AUTH_IDENTITY_REPOSITORY"],
+    },
+    {
+      provide: GetProfileUseCase,
+      useFactory: (
+        logger: ILoggerService,
+        userRepository: IUserRepository
+      ) => new GetProfileUseCase(logger, userRepository),
+      inject: [LoggerService, "USER_REPOSITORY"],
+    },
+    {
+      provide: UpdateProfileUseCase,
+      useFactory: (
+        logger: ILoggerService,
+        unitOfWork: IUnitOfWork,
+        userRepository: IUserRepository,
+        authIdentityRepository: IAuthIdentityRepository,
+        authIdentityUniquenessService: AuthIdentityUniquenessService,
+        organizationRepository: IOrganizationRepository,
+        organizationFacade: OrganizationFacade
+      ) =>
+        new UpdateProfileUseCase(
+          logger,
+          unitOfWork,
+          userRepository,
+          authIdentityRepository,
+          authIdentityUniquenessService,
+          organizationRepository,
+          organizationFacade
+        ),
+      inject: [
+        LoggerService,
+        TypeOrmUnitOfWork,
+        "USER_REPOSITORY",
+        "AUTH_IDENTITY_REPOSITORY",
+        AuthIdentityUniquenessService,
+        "ORGANIZATION_REPOSITORY",
+        OrganizationFacade,
+      ],
+    },
+    {
+      provide: DeleteAccountUseCase,
+      useFactory: (
+        logger: ILoggerService,
+        unitOfWork: IUnitOfWork,
+        userRepository: IUserRepository,
+        authIdentityRepository: IAuthIdentityRepository,
+        organizationRepository: IOrganizationRepository,
+        membershipRepository: IMembershipRepository,
+        authStrategy: IAuthStrategy
+      ) =>
+        new DeleteAccountUseCase(
+          logger,
+          unitOfWork,
+          userRepository,
+          authIdentityRepository,
+          organizationRepository,
+          membershipRepository,
+          authStrategy
+        ),
+        inject: [
+          LoggerService,
+          TypeOrmUnitOfWork,
+          "USER_REPOSITORY",
+          "AUTH_IDENTITY_REPOSITORY",
+          "ORGANIZATION_REPOSITORY",
+          "MEMBERSHIP_REPOSITORY",
+          "AUTH_IDENTITY_PROVIDER",
+        ],
+    },
+    {
+      provide: UserFacade,
+      useFactory: (
+        getProfileUseCase: GetProfileUseCase,
+        updateProfileUseCase: UpdateProfileUseCase,
+        deleteAccountUseCase: DeleteAccountUseCase
+      ) =>
+        new UserFacade(
+          getProfileUseCase,
+          updateProfileUseCase,
+          deleteAccountUseCase
+        ),
+      inject: [GetProfileUseCase, UpdateProfileUseCase, DeleteAccountUseCase],
+    },
+  ],
+  exports: [UserFacade],
+})
+export class UserModule {}
+


### PR DESCRIPTION
# User Profile Management API

## 📋 Summary
Implementation of a complete user profile management module following clean architecture principles, enabling users to view, update their profile, change passwords, and delete their accounts (admin only).

## 🎯 Features

### Profile Management
- **GET /v1/profile** - Retrieve current authenticated user profile
- **PUT /v1/profile** - Update user profile (firstName, lastName, email, organization name)
- **PUT /v1/profile/password** - Change user password (requires old password)
- **DELETE /v1/profile** - Delete user account (admin only)

### Role-Based Access Control
- Only admins can update organization name
- Only admins can delete their accounts
- Organization name uniqueness validation
- Email uniqueness validation

### Cascading Deletion
When an admin deletes their account:
- All owned organizations are deleted
- All memberships associated with deleted organizations are removed
- Users who are only members of deleted organizations are also deleted
- Users with multiple organization memberships only have their membership removed
- All related auth identities are cleaned up
