### PR TITLE
feat: add Excel export support for quiz statistics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "rxjs": "^7.8.1",
         "stripe": "^17.4.0",
         "typeorm": "^0.3.27",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -53,6 +54,7 @@
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
         "@types/supertest": "^6.0.2",
+        "@types/xlsx": "^0.0.35",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
@@ -5999,6 +6001,13 @@
       "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
       "license": "MIT"
     },
+    "node_modules/@types/xlsx": {
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/xlsx/-/xlsx-0.0.35.tgz",
+      "integrity": "sha512-s0x3DYHZzOkxtjqOk/Nv1ezGzpbN7I8WX+lzlV/nFfTDOv7x4d8ZwGHcnaiB8UCx89omPsftQhS5II3jeWePxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -6787,6 +6796,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -7541,6 +7559,19 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "license": "Apache-2.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7775,6 +7806,15 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -7997,6 +8037,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/create-require": {
@@ -9168,6 +9220,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -13140,6 +13201,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -14863,6 +14936,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -14971,6 +15062,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "rxjs": "^7.8.1",
     "stripe": "^17.4.0",
     "typeorm": "^0.3.27",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -68,6 +69,7 @@
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
+    "@types/xlsx": "^0.0.35",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/src/modules/organization/organization.module.ts
+++ b/src/modules/organization/organization.module.ts
@@ -47,6 +47,7 @@ import { GetOrganizationStatsUseCase } from "./application/use-cases/GetOrganiza
 import { ClassModule } from "../class/class.module";
 import { SubjectModule } from "../subject/subject.module";
 import { QuizModule } from "../quiz/quiz.module";
+import { SubscriptionModule } from "../subscription/subscription.module";
 import { IClassRepository } from "../class/domain/repositories/class.repository";
 import { ISubjectRepository } from "../subject/domain/repositories/subject.repository";
 import { IQuizRepository } from "../quiz/domain/repositories/quiz.repository";
@@ -79,9 +80,7 @@ import {
     forwardRef(() => ClassModule),
     forwardRef(() => SubjectModule),
     forwardRef(() => QuizModule),
-    forwardRef(
-      () => require("../subscription/subscription.module").SubscriptionModule
-    ),
+    forwardRef(() => SubscriptionModule),
   ],
   controllers: [OrganizationController, UserController],
   providers: [

--- a/src/modules/quiz/application/facades/quiz.facade.ts
+++ b/src/modules/quiz/application/facades/quiz.facade.ts
@@ -42,6 +42,11 @@ import { GetQuizByAccessTokenUseCase } from "../use-cases/GetQuizByAccessToken.u
 import { SubmitQuizResponseUseCase } from "../use-cases/SubmitQuizResponse.use-case";
 import { CheckQuizResponseStatusUseCase } from "../use-cases/CheckQuizResponseStatus.use-case";
 import { GetQuizStatisticsUseCase } from "../use-cases/GetQuizStatistics.use-case";
+import {
+  ExportQuizStatisticsUseCase,
+  ExportQuizStatisticsInput,
+  ExportQuizStatisticsOutput,
+} from "../use-cases/ExportQuizStatistics.use-case";
 
 export class QuizFacade {
   constructor(
@@ -59,6 +64,7 @@ export class QuizFacade {
     private readonly submitQuizResponseUseCase: SubmitQuizResponseUseCase,
     private readonly checkQuizResponseStatusUseCase: CheckQuizResponseStatusUseCase,
     private readonly getQuizStatisticsUseCase: GetQuizStatisticsUseCase,
+    private readonly exportQuizStatisticsUseCase: ExportQuizStatisticsUseCase,
   ) {}
 
   async getQuizTemplatePairs(
@@ -143,6 +149,12 @@ export class QuizFacade {
     data: GetQuizStatisticsInput,
   ): Promise<GetQuizStatisticsOutput> {
     return await this.getQuizStatisticsUseCase.execute(data);
+  }
+
+  async exportQuizStatistics(
+    data: ExportQuizStatisticsInput,
+  ): Promise<ExportQuizStatisticsOutput> {
+    return await this.exportQuizStatisticsUseCase.execute(data);
   }
 }
 

--- a/src/modules/quiz/application/use-cases/ExportQuizStatistics.use-case.ts
+++ b/src/modules/quiz/application/use-cases/ExportQuizStatistics.use-case.ts
@@ -1,0 +1,315 @@
+import {
+  IUseCase,
+  BaseUseCase,
+  ILoggerService,
+  DomainError,
+  ErrorCode,
+} from "src/core";
+import { IQuizRepository } from "../../domain/repositories/quiz.repository";
+import { IQuizTemplateRepository } from "../../domain/repositories/quiz-template.repository";
+import { IResponseRepository } from "../../domain/repositories/response.repository";
+import { IAnswerRepository } from "../../domain/repositories/answer.repository";
+import { OrganizationFacade } from "src/modules/organization/application/facades/organization.facade";
+import { ISubscriptionRepository } from "src/modules/subscription/domain/repositories/subscription.repository";
+import { ISubscriptionPlanRepository } from "src/modules/subscription/domain/repositories/subscription-plan.repository";
+import { ResponseEntity } from "../../domain/entities/response.entity";
+import { ResponseVisibilityService } from "../../domain/services/response-visibility.service";
+import * as XLSX from "xlsx";
+
+export interface ExportQuizStatisticsInput {
+  quizId: string;
+  organizationId: string;
+  userId: string;
+  format: "csv" | "xlsx";
+}
+
+export interface ExportQuizStatisticsOutput {
+  data: string | Buffer;
+  filename: string;
+  contentType: string;
+}
+
+export class ExportQuizStatisticsUseCase extends BaseUseCase implements IUseCase {
+  constructor(
+    readonly logger: ILoggerService,
+    private readonly quizRepository: IQuizRepository,
+    private readonly quizTemplateRepository: IQuizTemplateRepository,
+    private readonly responseRepository: IResponseRepository,
+    private readonly answerRepository: IAnswerRepository,
+    private readonly organizationFacade: OrganizationFacade,
+    private readonly responseVisibilityService: ResponseVisibilityService,
+    private readonly subscriptionRepository: ISubscriptionRepository,
+    private readonly subscriptionPlanRepository: ISubscriptionPlanRepository
+  ) {
+    super(logger);
+  }
+
+  async execute(
+    data: ExportQuizStatisticsInput
+  ): Promise<ExportQuizStatisticsOutput> {
+    try {
+      await this.organizationFacade.validateUserBelongsToOrganization(
+        data.userId,
+        data.organizationId
+      );
+
+      const quiz = await this.quizRepository.findById(data.quizId);
+      if (!quiz) {
+        throw new DomainError(ErrorCode.UNEXPECTED_ERROR, "Quiz not found");
+      }
+
+      const subscription =
+        await this.subscriptionRepository.findActiveByOrganizationId(
+          data.organizationId
+        );
+      const plan = subscription
+        ? await this.subscriptionPlanRepository.findById(subscription.planId)
+        : null;
+
+      const allResponses = await this.responseRepository.findByQuiz(
+        data.quizId
+      );
+
+      const responseEntities = allResponses.map((r) =>
+        ResponseEntity.reconstitute(r)
+      );
+
+      const visibleResponses =
+        this.responseVisibilityService.getVisibleResponses(
+          responseEntities,
+          subscription,
+          plan
+        );
+
+      const visibleResponseIds = new Set(visibleResponses.map((r) => r.id));
+      const responses = allResponses.filter((r) =>
+        visibleResponseIds.has(r.id)
+      );
+
+      const allAnswers = await this.answerRepository.findByQuiz(data.quizId);
+
+      const visibleAnswerResponseIds = new Set(responses.map((r) => r.id));
+      const visibleAnswers = allAnswers.filter((a) => {
+        const response = allResponses.find((r) => r.id === a.responseId);
+        return response && visibleAnswerResponseIds.has(response.id);
+      });
+
+      const template = await this.quizTemplateRepository.findById(
+        quiz.templateId
+      );
+      if (!template) {
+        throw new DomainError(ErrorCode.UNEXPECTED_ERROR, "Template not found");
+      }
+
+      const questions = template.questionsList.sort(
+        (a, b) => a.orderIndex - b.orderIndex
+      );
+
+      const responsesData = responses.map((r) => ({
+        id: r.id,
+        submittedAt: r.submittedAt,
+      }));
+
+      const answersData = visibleAnswers.map((a) => ({
+        id: a.id,
+        responseId: a.responseId,
+        questionId: a.questionId,
+        valueStars: a.valueStars,
+        valueRadio: a.valueRadio,
+        valueCheckbox: a.valueCheckbox,
+        valueText: a.valueText,
+      }));
+
+      const sanitizedQuizName = "quiz";
+      const dateStr = new Date().toISOString().split("T")[0];
+      
+      if (data.format === "xlsx") {
+        const buffer = this.generateExcel(questions, responsesData, answersData);
+        const filename = `retours_${sanitizedQuizName}_${dateStr}.xlsx`;
+        return {
+          data: buffer,
+          filename,
+          contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        };
+      } else {
+        const csv = this.generateCSV(questions, responsesData, answersData);
+        const filename = `retours_${sanitizedQuizName}_${dateStr}.csv`;
+        return {
+          data: csv,
+          filename,
+          contentType: "text/csv; charset=utf-8",
+        };
+      }
+    } catch (error) {
+      this.handleError(error);
+    }
+  }
+
+  private generateCSV(
+    questions: Array<{
+      id: string;
+      text: string;
+      type: "stars" | "radio" | "checkbox" | "textarea";
+      orderIndex: number;
+    }>,
+    responses: Array<{
+      id: string;
+      submittedAt: Date;
+    }>,
+    answers: Array<{
+      id: string;
+      responseId: string;
+      questionId: string;
+      valueStars: number | null;
+      valueRadio: string | null;
+      valueCheckbox: string[] | null;
+      valueText: string | null;
+    }>
+  ): string {
+    const escapeCSV = (value: string | number | null | undefined): string => {
+      if (value === null || value === undefined) return "";
+      const str = String(value);
+      if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+        return `"${str.replace(/"/g, '""')}"`;
+      }
+      return str;
+    };
+
+    const headers = [
+      "Date de soumission",
+      ...questions.map((q) => q.text),
+    ];
+
+    const csvRows: string[] = [headers.map(escapeCSV).join(",")];
+
+    const answersByResponse = new Map<string, Map<string, typeof answers[0]>>();
+    answers.forEach((answer) => {
+      if (!answersByResponse.has(answer.responseId)) {
+        answersByResponse.set(answer.responseId, new Map());
+      }
+      answersByResponse.get(answer.responseId)!.set(answer.questionId, answer);
+    });
+
+    const sortedResponses = [...responses].sort(
+      (a, b) => new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime()
+    );
+
+    sortedResponses.forEach((response) => {
+      const responseAnswers = answersByResponse.get(response.id) || new Map();
+      const row = [
+        new Date(response.submittedAt).toLocaleString("fr-FR", {
+          day: "2-digit",
+          month: "2-digit",
+          year: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        }),
+        ...questions.map((question) => {
+          const answer = responseAnswers.get(question.id);
+          if (!answer) return "";
+
+          if (question.type === "stars" && answer.valueStars !== null) {
+            return String(answer.valueStars);
+          } else if (question.type === "radio" && answer.valueRadio) {
+            return answer.valueRadio;
+          } else if (
+            question.type === "checkbox" &&
+            answer.valueCheckbox &&
+            answer.valueCheckbox.length > 0
+          ) {
+            return answer.valueCheckbox.join("; ");
+          } else if (question.type === "textarea" && answer.valueText) {
+            return answer.valueText;
+          }
+          return "";
+        }),
+      ];
+      csvRows.push(row.map(escapeCSV).join(","));
+    });
+
+    return csvRows.join("\n");
+  }
+
+  private generateExcel(
+    questions: Array<{
+      id: string;
+      text: string;
+      type: "stars" | "radio" | "checkbox" | "textarea";
+      orderIndex: number;
+    }>,
+    responses: Array<{
+      id: string;
+      submittedAt: Date;
+    }>,
+    answers: Array<{
+      id: string;
+      responseId: string;
+      questionId: string;
+      valueStars: number | null;
+      valueRadio: string | null;
+      valueCheckbox: string[] | null;
+      valueText: string | null;
+    }>
+  ): Buffer {
+    const headers = [
+      "Date de soumission",
+      ...questions.map((q) => q.text),
+    ];
+
+    const answersByResponse = new Map<string, Map<string, typeof answers[0]>>();
+    answers.forEach((answer) => {
+      if (!answersByResponse.has(answer.responseId)) {
+        answersByResponse.set(answer.responseId, new Map());
+      }
+      answersByResponse.get(answer.responseId)!.set(answer.questionId, answer);
+    });
+
+    const sortedResponses = [...responses].sort(
+      (a, b) => new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime()
+    );
+
+    const rows: any[][] = [headers];
+    
+    sortedResponses.forEach((response) => {
+      const responseAnswers = answersByResponse.get(response.id) || new Map();
+      const row = [
+        new Date(response.submittedAt).toLocaleString("fr-FR", {
+          day: "2-digit",
+          month: "2-digit",
+          year: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        }),
+        ...questions.map((question) => {
+          const answer = responseAnswers.get(question.id);
+          if (!answer) return "";
+
+          if (question.type === "stars" && answer.valueStars !== null) {
+            return answer.valueStars;
+          } else if (question.type === "radio" && answer.valueRadio) {
+            return answer.valueRadio;
+          } else if (
+            question.type === "checkbox" &&
+            answer.valueCheckbox &&
+            answer.valueCheckbox.length > 0
+          ) {
+            return answer.valueCheckbox.join("; ");
+          } else if (question.type === "textarea" && answer.valueText) {
+            return answer.valueText;
+          }
+          return "";
+        }),
+      ];
+      rows.push(row);
+    });
+
+    const ws = XLSX.utils.aoa_to_sheet(rows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "Retours");
+    
+    return XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+  }
+
+  async withCompensation(): Promise<void> {}
+}
+

--- a/src/modules/quiz/quiz.module.ts
+++ b/src/modules/quiz/quiz.module.ts
@@ -50,6 +50,7 @@ import { GetQuizByAccessTokenUseCase } from "./application/use-cases/GetQuizByAc
 import { SubmitQuizResponseUseCase } from "./application/use-cases/SubmitQuizResponse.use-case";
 import { CheckQuizResponseStatusUseCase } from "./application/use-cases/CheckQuizResponseStatus.use-case";
 import { GetQuizStatisticsUseCase } from "./application/use-cases/GetQuizStatistics.use-case";
+import { ExportQuizStatisticsUseCase } from "./application/use-cases/ExportQuizStatistics.use-case";
 
 import { QuizFacade } from "./application/facades/quiz.facade";
 
@@ -590,6 +591,42 @@ import { SubscriptionFeatureService } from "../subscription/domain/services/subs
       ],
     },
     {
+      provide: ExportQuizStatisticsUseCase,
+      useFactory: (
+        logger: ILoggerService,
+        quizRepository: IQuizRepository,
+        quizTemplateRepository: IQuizTemplateRepository,
+        responseRepository: IResponseRepository,
+        answerRepository: IAnswerRepository,
+        organizationFacade: OrganizationFacade,
+        responseVisibilityService: ResponseVisibilityService,
+        subscriptionRepository: ISubscriptionRepository,
+        subscriptionPlanRepository: ISubscriptionPlanRepository
+      ) =>
+        new ExportQuizStatisticsUseCase(
+          logger,
+          quizRepository,
+          quizTemplateRepository,
+          responseRepository,
+          answerRepository,
+          organizationFacade,
+          responseVisibilityService,
+          subscriptionRepository,
+          subscriptionPlanRepository
+        ),
+      inject: [
+        LoggerService,
+        "QUIZ_REPOSITORY",
+        "QUIZ_TEMPLATE_REPOSITORY",
+        "RESPONSE_REPOSITORY",
+        "ANSWER_REPOSITORY",
+        OrganizationFacade,
+        ResponseVisibilityService,
+        SUBSCRIPTION_REPOSITORY,
+        SUBSCRIPTION_PLAN_REPOSITORY,
+      ],
+    },
+    {
       provide: QuizFacade,
       useFactory: (
         getQuizTemplatePairsUseCase: GetQuizTemplatePairsUseCase,
@@ -605,7 +642,8 @@ import { SubscriptionFeatureService } from "../subscription/domain/services/subs
         getQuizByAccessTokenUseCase: GetQuizByAccessTokenUseCase,
         submitQuizResponseUseCase: SubmitQuizResponseUseCase,
         checkQuizResponseStatusUseCase: CheckQuizResponseStatusUseCase,
-        getQuizStatisticsUseCase: GetQuizStatisticsUseCase
+        getQuizStatisticsUseCase: GetQuizStatisticsUseCase,
+        exportQuizStatisticsUseCase: ExportQuizStatisticsUseCase
       ) =>
         new QuizFacade(
           getQuizTemplatePairsUseCase,
@@ -621,7 +659,8 @@ import { SubscriptionFeatureService } from "../subscription/domain/services/subs
           getQuizByAccessTokenUseCase,
           submitQuizResponseUseCase,
           checkQuizResponseStatusUseCase,
-          getQuizStatisticsUseCase
+          getQuizStatisticsUseCase,
+          exportQuizStatisticsUseCase
         ),
       inject: [
         GetQuizTemplatePairsUseCase,
@@ -638,6 +677,7 @@ import { SubscriptionFeatureService } from "../subscription/domain/services/subs
         SubmitQuizResponseUseCase,
         CheckQuizResponseStatusUseCase,
         GetQuizStatisticsUseCase,
+        ExportQuizStatisticsUseCase,
       ],
     },
     ResponseVisibilityService,


### PR DESCRIPTION
- Install xlsx package and @types/xlsx for Excel file generation
- Extend ExportQuizStatisticsUseCase to support both CSV and XLSX formats
- Add generateExcel() method using xlsx library to create Excel workbooks
- Update ExportQuizStatisticsInput interface to include format parameter ("csv" | "xlsx")
- Update ExportQuizStatisticsOutput interface to return data (string | Buffer), filename, and contentType
- Modify quiz export endpoint to accept format query parameter (defaults to "csv")
- Update Content-Type headers based on export format (text/csv or application/vnd.openxmlformats-officedocument.spreadsheetml.sheet)